### PR TITLE
Adds optional parameter for nodes to request security group

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -66,7 +66,8 @@ class KubeControlProvider(RelationBase):
     def auth_user(self):
         """ return the kubelet_user value on the wire from the requestor """
         conv = self.conversation()
-        return (conv.scope, conv.get_remote('kubelet_user'))
+        return (conv.scope, {'user': conv.get_remote('kubelet_user'),
+                             'group': conv.get_remote('auth_group')})
 
     def sign_auth_request(self, kubelet_token, proxy_token, client_token):
         """Send authorization tokens to the requesting unit """

--- a/requires.py
+++ b/requires.py
@@ -82,11 +82,16 @@ class KubeControlRequireer(RelationBase):
         """
         return all(self.get_dns().values())
 
-    def set_auth_request(self, kubelet):
+    def set_auth_request(self, kubelet, group='system:nodes'):
         """ Tell the master that we are requesting auth, and to use this
-        hostname for the kubelet system account """
+        hostname for the kubelet system account.
+
+        Param groups - Determines the level of eleveted privleges of the
+        requested user. Can be overridden to request sudo level access on the
+        cluster via changing to system:masters """
         conv = self.conversation()
-        conv.set_remote(data={'kubelet_user': kubelet})
+        conv.set_remote(data={'kubelet_user': kubelet,
+                              'auth_group': group})
 
     def set_gpu(self, enabled=True):
         """Tell the master that we're gpu-enabled (or not).


### PR DESCRIPTION
This allows applications that require elevated privleges to request
them. Such as kubernetes-e2e requires master level privs to probe the
cluster and execute/validate across namespaces.