### PR TITLE
Adds departing state/method

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Kubernetes cluster.
 
   Enabled when any worker has indicated that it is running in gpu mode.
 
+* `kube-control.departed`
+
+  Enabled when any worker has indicated that it is leaving the cluster.
+
 
 * `kube-control.auth.requested`
 
@@ -40,6 +44,12 @@ Kubernetes cluster.
   Sends authentication tokens to the requesting unit for the requested user
   and kube-proxy services.
 
+* `kube_control.flush_departed()`
+
+  Returns the unit departing the kube_control relationship so you can do any
+  post removal cleanup. Such as removing authentication tokens for the unit.
+  Invoking this method will also remove the `kube-control.departed` state
+
 ### Examples
 
 ```python
@@ -53,6 +63,14 @@ def send_dns(kube_control):
 def on_gpu_available(kube_control):
     # The remote side is gpu-enable, handle it somehow
     assert kube_control.get_gpu() == True
+
+
+@when('kube-control.departed')
+@when('leadership.is_leader')
+def flush_auth_for_departed(kube_control):
+    ''' Unit has left the cluster and needs to have its authentication
+    tokens removed from the token registry '''
+    departing_unit = kube_control.flush_departed()
 
 ```
 

--- a/provides.py
+++ b/provides.py
@@ -38,7 +38,7 @@ class KubeControlProvider(RelationBase):
         if self._has_auth_request():
             conv.set_state('{relation_name}.auth.requested')
 
-    @hook('{provides:kube-control}-relation-{broken,departed}')
+    @hook('{provides:kube-control}-relation-departed')
     def departed(self):
         """Remove all states.
 
@@ -46,6 +46,15 @@ class KubeControlProvider(RelationBase):
         conv = self.conversation()
         conv.remove_state('{relation_name}.connected')
         conv.remove_state('{relation_name}.gpu.available')
+        conv.set_state('{relation_name}.departed')
+
+    def flush_departed(self):
+        """Remove the signal state that we have a unit departing the
+        relationship. Additionally return the unit departing so the host can
+        do any cleanup logic required. """
+        conv = self.conversation()
+        conv.remove_state('{relation_name}.departed')
+        return conv.scope
 
     def set_dns(self, port, domain, sdn_ip):
         """Send DNS info to the remote units.


### PR DESCRIPTION
As a member leaves the cluster, we will need to triage auth tokens
associated with that unit. This provides the plumbing to signal and
return the departing unit for the context.