### PR TITLE
Refactor to use new Endpoint base class

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -43,9 +43,9 @@ class KubeControlProvider(Endpoint):
         clear_flag(self.flag('endpoint.{relation_name}.changed.gpu'))
         hookenv.log('Checking for gpu-enabled workers')
 
-        # json_receive automatically decodes bool values, but existing
+        # received_json automatically decodes bool values, but existing
         # relations may have the older string form
-        gpu_enabled = self.all_units.json_receive['gpu'] in (True, 'True')
+        gpu_enabled = self.all_units.received_json['gpu'] in (True, 'True')
         toggle_flag(self.flag('endpoint.{relation_name}.gpu.available'),
                     should_set=gpu_enabled)
         toggle_flag(self.flag('{relation_name}.gpu.available'),  # legacy flag
@@ -58,7 +58,7 @@ class KubeControlProvider(Endpoint):
         be run everywhere there is a kubelet.
         """
         clear_flag(self.flag('endpoint.{relation_name}.changed.kubelet_user'))
-        auth_requested = self.all_units.receive['kubelet_user']
+        auth_requested = self.all_units.received['kubelet_user']
         toggle_flag(self.flag('endpoint.{relation_name}.auth.requested'),
                     should_set=auth_requested)
         toggle_flag(self.flag('{relation_name}.auth.requested'),  # legacy flag
@@ -101,8 +101,8 @@ class KubeControlProvider(Endpoint):
         for unit in self.all_units:
             # NB: These values aren't actually used by the master, and we
             # ought to just send the relations (or relation_ids).
-            user = unit.receive['kubelet_user']
-            group = unit.receive['auth_group']
+            user = unit.received['kubelet_user']
+            group = unit.received['auth_group']
             if not (user and group):
                 continue
             requests.append((unit, {'user': user,

--- a/requires.py
+++ b/requires.py
@@ -61,9 +61,9 @@ class KubeControlRequireer(Endpoint):
 
         """
         return {
-            'kubelet_token': self.all_units.receive['kubelet_token'],
-            'proxy_token': self.all_units.receive['proxy_token'],
-            'client_token': self.all_units.receive['client_token'],
+            'kubelet_token': self.all_units.received['kubelet_token'],
+            'proxy_token': self.all_units.received['proxy_token'],
+            'client_token': self.all_units.received['client_token'],
         }
 
     def get_dns(self):
@@ -71,10 +71,10 @@ class KubeControlRequireer(Endpoint):
 
         """
         return {
-            'private-address': self.all_units.receive['private-address'],
-            'port': self.all_units.receive['port'],
-            'domain': self.all_units.receive['domain'],
-            'sdn-ip': self.all_units.receive['sdn-ip'],
+            'private-address': self.all_units.received['private-address'],
+            'port': self.all_units.received['port'],
+            'domain': self.all_units.received['domain'],
+            'sdn-ip': self.all_units.received['sdn-ip'],
         }
 
     def dns_ready(self):
@@ -100,7 +100,7 @@ class KubeControlRequireer(Endpoint):
         """
         hookenv.log('Setting gpu={} on kube-control relation'.format(enabled))
         for relation in self.relations:  # should only ever be one relation
-            relation.json_send['gpu'] = enabled
+            relation.send_json['gpu'] = enabled
 
     def _has_auth_credentials(self):
         """Predicate method to signal we have authentication credentials """

--- a/requires.py
+++ b/requires.py
@@ -11,69 +11,70 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from charms.reactive import RelationBase
-from charms.reactive import hook
-from charms.reactive import scopes
+from charms.reactive import Endpoint
+from charms.reactive import when
+from charms.reactive import when_not
+from charms.reactive import set_flag
+from charms.reactive import clear_flag
+from charms.reactive import toggle_flag
 
 from charmhelpers.core import hookenv
 
 
-class KubeControlRequireer(RelationBase):
+# TODO: update charms and remove legacy flags
+class KubeControlRequireer(Endpoint):
     """Implements the kubernetes-worker side of the kube-control interface.
 
     """
-    scope = scopes.GLOBAL
+    @when('endpoint.{relation_name}.joined')
+    def legacy_flag_connected(self):
+        set_flag(self.flag('{relation_name}.connected'))
 
-    @hook('{requires:kube-control}-relation-{joined,changed}')
-    def joined_or_changed(self):
+    @when('endpoint.{relation_name}.changed')
+    def changed(self):
         """Set states corresponding to the data we have.
 
         """
-        conv = self.conversation()
-        conv.set_state('{relation_name}.connected')
+        toggle_flag(self.flag('endpoint.{relation_name}.dns.available'),
+                    should_set=self.dns_ready())
+        toggle_flag(self.flag('endpoint.{relation_name}.auth.available'),
+                    should_set=self._has_auth_credentials())
 
-        if self.dns_ready():
-            conv.set_state('{relation_name}.dns.available')
-        else:
-            conv.remove_state('{relation_name}.dns.available')
+        toggle_flag(self.flag('{relation_name}.dns.available'),  # legacy flag
+                    should_set=self.dns_ready())
+        toggle_flag(self.flag('{relation_name}.auth.available'),  # legacy flag
+                    should_set=self._has_auth_credentials())
 
-        if self._has_auth_credentials():
-            conv.set_state('{relation_name}.auth.available')
-        else:
-            conv.remove_state('{relation_name}.auth.available')
-
-    @hook('{requires:kube-control}-relation-{broken,departed}')
-    def departed(self):
+    @when_not('endpoint.{relation_name}.joined')
+    def broken(self):
         """Remove all states.
 
         """
-        conv = self.conversation()
-        conv.remove_state('{relation_name}.connected')
-        conv.remove_state('{relation_name}.dns.available')
+        clear_flag(self.flag('endpoint.{relation_name}.dns.available'))
+        clear_flag(self.flag('endpoint.{relation_name}.auth.available'))
+        clear_flag(self.flag('{relation_name}.connected'))  # legacy flag
+        clear_flag(self.flag('{relation_name}.dns.available'))  # legacy flag
+        clear_flag(self.flag('{relation_name}.auth.available'))  # legacy flag
 
     def get_auth_credentials(self):
         """ Return the authentication credentials.
 
         """
-        conv = self.conversation()
-
         return {
-            'kubelet_token': conv.get_remote('kubelet_token'),
-            'proxy_token': conv.get_remote('proxy_token'),
-            'client_token': conv.get_remote('client_token')
+            'kubelet_token': self.all_units.receive['kubelet_token'],
+            'proxy_token': self.all_units.receive['proxy_token'],
+            'client_token': self.all_units.receive['client_token'],
         }
 
     def get_dns(self):
         """Return DNS info provided by the master.
 
         """
-        conv = self.conversation()
-
         return {
-            'private-address': conv.get_remote('private-address'),
-            'port': conv.get_remote('port'),
-            'domain': conv.get_remote('domain'),
-            'sdn-ip': conv.get_remote('sdn-ip'),
+            'private-address': self.all_units.receive['private-address'],
+            'port': self.all_units.receive['port'],
+            'domain': self.all_units.receive['domain'],
+            'sdn-ip': self.all_units.receive['sdn-ip'],
         }
 
     def dns_ready(self):
@@ -89,20 +90,18 @@ class KubeControlRequireer(RelationBase):
         Param groups - Determines the level of eleveted privleges of the
         requested user. Can be overridden to request sudo level access on the
         cluster via changing to system:masters """
-        conv = self.conversation()
-        conv.set_remote(data={'kubelet_user': kubelet,
-                              'auth_group': group})
+        for relation in self.relations:  # should only ever be one relation
+            relation.send.update({'kubelet_user': kubelet,
+                                  'auth_group': group})
 
     def set_gpu(self, enabled=True):
         """Tell the master that we're gpu-enabled (or not).
 
         """
         hookenv.log('Setting gpu={} on kube-control relation'.format(enabled))
-        conv = self.conversation()
-        conv.set_remote(gpu=enabled)
+        for relation in self.relations:  # should only ever be one relation
+            relation.json_send['gpu'] = enabled
 
     def _has_auth_credentials(self):
         """Predicate method to signal we have authentication credentials """
-        conv = self.conversation()
-        if conv.get_remote('kubelet_token') and conv.get_remote('proxy_token'):
-            return True
+        return all(self.get_auth_credentials().values())


### PR DESCRIPTION
**DON'T MERGE THIS**
At least until juju-solutions/charms.reactive#123 is merged and released.

This changes the layer to use the new Endpoint base class for interface layers, from juju-solutions/charms.reactive#123.  Some of this could be cleaned up a bit more with changes to the charm, but I wanted to keep it backwards compatible for now.

This also requires juju-solutions/charm-flannel#38, which is available in revision 32 and higher of the flannel charm in the charm store, due to the changes in the reactive lib.