### PR TITLE
Add support for sign credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Kubernetes cluster.
   Returns a list of the requested username and group requested for
   authentication.
 
-* `kube_control.sign_auth_request(scope, kubelet_token, proxy_token, client_token)`
+* `kube_control.sign_auth_request(scope, user, kubelet_token, proxy_token, client_token)`
 
   Sends authentication tokens to the unit scope for the requested user
   and kube-proxy services.
@@ -103,9 +103,9 @@ def flush_auth_for_departed(kube_control):
 
   Tell the master that we are gpu-enabled.
 
-*  `kube_control.get_auth_credentials()`
+*  `kube_control.get_auth_credentials(user)`
 
-  Returns a dict with the returned authentication credentials.
+  Returns a dict with the users authentication credentials.
 
 *  `set_auth_request(kubelet, group='system:nodes')`
 
@@ -133,7 +133,7 @@ def send_gpu(kube_control):
 @when('kube-control.auth.available')
 def display_auth_tokens(kube_control):
     # Remote side has sent auth info
-    auth = kube_control.get_auth_credentials()
+    auth = kube_control.get_auth_credentials('root')
     print(auth['kubelet_token'])
     print(auth['proxy_token'])
     print(auth['client_token'])

--- a/provides.py
+++ b/provides.py
@@ -63,6 +63,7 @@ class KubeControlProvider(RelationBase):
         for user, cred in list(all_creds.items()):
             if cred['scope'] == conv.scope:
                 all_creds.pop(user)
+                db.set('creds', all_creds)
         return conv.scope
 
     def set_dns(self, port, domain, sdn_ip):

--- a/provides.py
+++ b/provides.py
@@ -82,11 +82,12 @@ class KubeControlProvider(RelationBase):
                              'group': conv.get_remote('auth_group')}))
         return requests
 
-    def sign_auth_request(self, scope, kubelet_token, proxy_token,
+    def sign_auth_request(self, scope, user, kubelet_token, proxy_token,
                           client_token):
         """Send authorization tokens to the requesting unit """
         conv = self.conversation(scope)
-        conv.set_remote(data={'kubelet_token': kubelet_token,
+        conv.set_remote(data={'user': user,
+                              'kubelet_token': kubelet_token,
                               'proxy_token': proxy_token,
                               'client_token': client_token})
         conv.remove_state('{relation_name}.auth.requested')

--- a/provides.py
+++ b/provides.py
@@ -60,7 +60,7 @@ class KubeControlProvider(RelationBase):
         conv = self.conversation()
         conv.remove_state('{relation_name}.departed')
         all_creds = db.get('creds')
-        for user,cred in list(all_creds.items()):
+        for user, cred in list(all_creds.items()):
             if cred['scope'] == conv.scope:
                 all_creds.pop(user)
         return conv.scope
@@ -94,10 +94,10 @@ class KubeControlProvider(RelationBase):
                           client_token):
         """Send authorization tokens to the requesting unit """
         conv = self.conversation(scope)
-        cred={'scope': scope,
-              'kubelet_token': kubelet_token,
-              'proxy_token': proxy_token,
-              'client_token': client_token}
+        cred = {'scope': scope,
+                'kubelet_token': kubelet_token,
+                'proxy_token': proxy_token,
+                'client_token': client_token}
         if not db.get('creds'):
             db.set('creds', {})
 

--- a/provides.py
+++ b/provides.py
@@ -10,12 +10,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 
 from charms.reactive import RelationBase
 from charms.reactive import hook
 from charms.reactive import scopes
 
-from charmhelpers.core import hookenv
+from charmhelpers.core import hookenv, unitdata
+
+
+db = unitdata.kv()
 
 
 class KubeControlProvider(RelationBase):
@@ -55,6 +59,10 @@ class KubeControlProvider(RelationBase):
         do any cleanup logic required. """
         conv = self.conversation()
         conv.remove_state('{relation_name}.departed')
+        all_creds = db.get('creds')
+        for user,cred in list(all_creds.items()):
+            if cred['scope'] == conv.scope:
+                all_creds.pop(user)
         return conv.scope
 
     def set_dns(self, port, domain, sdn_ip):
@@ -86,10 +94,17 @@ class KubeControlProvider(RelationBase):
                           client_token):
         """Send authorization tokens to the requesting unit """
         conv = self.conversation(scope)
-        conv.set_remote(data={'user': user,
-                              'kubelet_token': kubelet_token,
-                              'proxy_token': proxy_token,
-                              'client_token': client_token})
+        cred={'scope': scope,
+              'kubelet_token': kubelet_token,
+              'proxy_token': proxy_token,
+              'client_token': client_token}
+        if not db.get('creds'):
+            db.set('creds', {})
+
+        all_creds = db.get('creds')
+        all_creds[user] = cred
+        db.set('creds', all_creds)
+        conv.set_remote(data={'creds': json.dumps(all_creds)})
         conv.remove_state('{relation_name}.auth.requested')
 
     def _get_gpu(self):

--- a/requires.py
+++ b/requires.py
@@ -58,6 +58,7 @@ class KubeControlRequireer(RelationBase):
         conv = self.conversation()
 
         return {
+            'user': conv.get_remote('user'),
             'kubelet_token': conv.get_remote('kubelet_token'),
             'proxy_token': conv.get_remote('proxy_token'),
             'client_token': conv.get_remote('client_token')

--- a/requires.py
+++ b/requires.py
@@ -57,8 +57,11 @@ class KubeControlRequireer(RelationBase):
 
         """
         conv = self.conversation()
+        remote_creds = conv.get_remote('creds')
+        if not remote_creds:
+            return None
 
-        all_creds = json.loads(conv.get_remote('creds'))
+        all_creds = json.loads(remote_creds)
         if user in all_creds:
             return {
                 'user': user,


### PR DESCRIPTION
This is needed for the work of RBAC support. Nodes can now request their own token to be used from kubelet. They all share the kube proxy token.