### PR TITLE
Fix bug with many masters

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -53,26 +53,6 @@ class KubeControlProvider(RelationBase):
         conv.remove_state('{relation_name}.auth.requested')
         conv.set_state('{relation_name}.departed')
 
-    def flush_departed(self):
-        """Remove the signal state that we have a unit departing the
-        relationship. Additionally return the unit departing so the host can
-        do any cleanup logic required. """
-        departed_scopes = []
-        for conv in self.conversations():
-            if conv.scope is None:
-                continue
-            if conv.is_state('{relation_name}.departed'):
-                departed_scopes.append(conv.scope)
-                conv.remove_state('{relation_name}.departed')
-        all_creds = db.get('creds')
-        if all_creds:
-            for user, cred in list(all_creds.items()):
-                if cred['scope'] in departed_scopes:
-                    all_creds.pop(user)
-            db.set('creds', all_creds)
-
-        return departed_scopes
-
     def set_dns(self, port, domain, sdn_ip):
         """Send DNS info to the remote units.
 

--- a/requires.py
+++ b/requires.py
@@ -49,8 +49,9 @@ class KubeControlRequireer(RelationBase):
 
         """
         conv = self.conversation()
-        conv.remove_state('{relation_name}.connected')
-        conv.remove_state('{relation_name}.dns.available')
+        if len(conv.units) == 1:
+            conv.remove_state('{relation_name}.connected')
+            conv.remove_state('{relation_name}.dns.available')
 
     def get_auth_credentials(self, user):
         """ Return the authentication credentials.


### PR DESCRIPTION
We cannot flush the kubelet tokens because we cannot distinguish if it is the master that is killed or the workers. In the case of a master departing tokens should not be flushed because another master will take over. If it is a worker that departs then we would like to remove the tokens. However we cannot distinguish between the two cases because when we do juju remove-unit kubernetes-master juju starts by breaking all relations that unit had.