### PR TITLE
remove additional flags on departed/broken

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -62,6 +62,9 @@ class KubeControlRequireer(RelationBase):
         if len(conv.units) == 1:
             conv.remove_state('{relation_name}.connected')
             conv.remove_state('{relation_name}.dns.available')
+            conv.remove_state('{relation_name}.auth.available')
+            conv.remove_state('{relation_name}.cluster_tag.available')
+            conv.remove_state('{relation_name}.registry_location.available')
 
     def get_auth_credentials(self, user):
         """ Return the authentication credentials.


### PR DESCRIPTION
If we don't do this, we'll fire handlers on -broken and -departed that we don't want fired, eg:

https://github.com/charmed-kubernetes/charm-kubernetes-worker/blob/ab000b8a48a7ed2f9df4c85a21564ab6420310b2/reactive/kubernetes_worker.py#L1316