### PR TITLE
remove states when all related units are gone

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -40,9 +40,16 @@ class KubeControlRequireer(RelationBase):
 
         """
         conv = self.conversation()
-        if len(conv.units) == 1:
+        # Make sure we have valid states as long as we still have related
+        # units. Once all units are gone, clear all states.
+        if hookenv.related_units():
+            self.check_states()
+        else:
             conv.remove_state('{relation_name}.connected')
-        self.check_states()
+            conv.remove_state('{relation_name}.dns.available')
+            conv.remove_state('{relation_name}.auth.available')
+            conv.remove_state('{relation_name}.cluster_tag.available')
+            conv.remove_state('{relation_name}.registry_location.available')
 
     def check_states(self):
         """Toggle states based on available data.


### PR DESCRIPTION
Follow on to #24 to remove states when the relation is departing.  It appears that `conv.units` is still showing all related k8s-masters even after the -departed hooks have run.  Even worse, all remote data is still available during -departed, so we never removed the various `.available` states.

`hookenv.related_units` actually decrements with each -departed hook, so let's use that as our trigger to know when it's safe to remove states.  This allows us to remove a single k8s-master (in HA) and still have accurate states on -departed; it also obviously removes all states if all `related_units` are gone.