### PR TITLE
Fix error adding worker after leader-changed from master-0 to master-1

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -106,7 +106,9 @@ class KubeControlRequirer(Endpoint):
         """
         Return the authentication credentials.
         """
-        rx = self.all_joined_units.received.get('creds')
+        rx = {}
+        for unit in self.all_joined_units:
+            rx.update(unit.received.get('creds'))
         if not rx:
             return None
 

--- a/requires.py
+++ b/requires.py
@@ -108,7 +108,7 @@ class KubeControlRequirer(Endpoint):
         """
         rx = {}
         for unit in self.all_joined_units:
-            rx.update(unit.received.get('creds'))
+            rx.update(unit.received.get('creds', {}))
         if not rx:
             return None
 


### PR DESCRIPTION
This fix takes creds from all masters and merge them.
Because if master-0 is off, then leader has changed to master-1,
there is still creds on master-0 relation data without proper data.

Closes-bug:#1839704