### PR TITLE
Add default CNI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "3.5"
+install:
+  - pip install tox-travis
+script:
+  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "3.5"
+  - "3.6"
+  - "3.7"
 install:
   - pip install tox-travis
 script:

--- a/interface.yaml
+++ b/interface.yaml
@@ -2,3 +2,5 @@ name: kube-control
 summary: Provides master-worker communication.
 version: 1
 maintainer: "Tim Van Steenburgh <tim.van.steenburgh@canonical.com>"
+ignore:
+- tests

--- a/provides.py
+++ b/provides.py
@@ -125,3 +125,10 @@ class KubeControlProvider(Endpoint):
         """
         for relation in self.relations:
             relation.to_publish['cohort-keys'] = cohort_keys
+
+    def set_default_cni(self, default_cni):
+        """
+        Send the default CNI.
+        """
+        for relation in self.relations:
+            relation.to_publish['default-cni'] = default_cni

--- a/provides.py
+++ b/provides.py
@@ -128,7 +128,10 @@ class KubeControlProvider(Endpoint):
 
     def set_default_cni(self, default_cni):
         """
-        Send the default CNI.
+        Send the default CNI. The default_cni value should be a string
+        containing the name of a related CNI application to use as the
+        default CNI. For example: "flannel" or "calico". If no default has
+        been chosen then "" can be sent instead.
         """
         for relation in self.relations:
             relation.to_publish['default-cni'] = default_cni

--- a/requires.py
+++ b/requires.py
@@ -45,6 +45,9 @@ class KubeControlRequirer(Endpoint):
         toggle_flag(
             self.expand_name('{endpoint_name}.cohort_keys.available'),
             self.is_joined and self.cohort_keys)
+        toggle_flag(
+            self.expand_name('{endpoint_name}.default_cni.available'),
+            self.is_joined and self.get_default_cni() is not None)
 
     def get_auth_credentials(self, user):
         """
@@ -138,3 +141,9 @@ class KubeControlRequirer(Endpoint):
         The cohort snapshot keys sent by the masters.
         """
         return self.all_joined_units.received['cohort-keys']
+
+    def get_default_cni(self):
+        """
+        Default CNI network to use.
+        """
+        return self.all_joined_units.received['default-cni']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+import sys
+from unittest.mock import MagicMock
+
+charmhelpers = MagicMock()
+sys.modules['charmhelpers'] = charmhelpers
+sys.modules['charmhelpers.core'] = charmhelpers.core
+sys.modules['charmhelpers.core.hookenv'] = charmhelpers.core.hookenv
+
+charms = MagicMock()
+sys.modules['charms'] = charms
+sys.modules['charms.reactive'] = charms.reactive
+
+
+class MockEndpoint(MagicMock):
+    @property
+    def endpoint_name(self):
+        return 'kube-control'
+
+    def expand_name(self, name):
+        return name.replace('{endpoint_name}', self.endpoint_name)
+
+
+charms.reactive.Endpoint = MockEndpoint

--- a/tests/test_provides.py
+++ b/tests/test_provides.py
@@ -1,0 +1,13 @@
+from unittest.mock import MagicMock
+import provides
+
+
+def test_set_default_cni():
+    provider = provides.KubeControlProvider()
+    provider.relations = [MagicMock(), MagicMock()]
+    provider.set_default_cni('test')
+    for relation in provider.relations:
+        relation.to_publish.__setitem__.assert_called_once_with(
+            'default-cni',
+            'test'
+        )

--- a/tests/test_requires.py
+++ b/tests/test_requires.py
@@ -1,0 +1,7 @@
+import requires
+
+
+def test_get_default_cni():
+    requirer = requires.KubeControlRequirer()
+    requirer.all_joined_units.received = {'default-cni': 'test'}
+    assert requirer.get_default_cni() == 'test'

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+skipsdist = True
+envlist = lint,py3
+
+[tox:travis]
+3.5: lint,py3
+
+[testenv]
+basepython = python3
+setenv =
+    PYTHONPATH={toxinidir}:{toxinidir}/lib
+deps =
+    pyyaml
+    pytest
+    flake8
+    ipdb
+commands = pytest --tb native -s {posargs}
+
+[testenv:lint]
+envdir = {toxworkdir}/py3
+commands = flake8 {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@ envlist = lint,py3
 
 [tox:travis]
 3.5: lint,py3
+3.6: lint,py3
+3.7: lint,py3
 
 [testenv]
 basepython = python3


### PR DESCRIPTION
Partial fix for https://bugs.launchpad.net/charm-kubernetes-master/+bug/1861709

Please be careful merging this, as it's mutually dependent on the work of other PRs in that issue. They will need to be merged together.

This allows kubernetes-master to send its default-cni config over the kube-control relation to kubernetes-worker.