### PR TITLE
Add support for sending API endpoint URLs

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -150,3 +150,11 @@ class KubeControlProvider(Endpoint):
         """
         for relation in self.relations:
             relation.to_publish['default-cni'] = default_cni
+
+    def set_api_endpoints(self, endpoints):
+        """
+        Send the list of API endpoint URLs to which workers should connect.
+        """
+        endpoints = sorted(endpoints)
+        for relation in self.relations:
+            relation.to_publish['api-endpoints'] = endpoints

--- a/requires.py
+++ b/requires.py
@@ -48,6 +48,9 @@ class KubeControlRequirer(Endpoint):
         toggle_flag(
             self.expand_name('{endpoint_name}.default_cni.available'),
             self.is_joined and self.get_default_cni() is not None)
+        toggle_flag(
+            self.expand_name('{endpoint_name}.api_endpoints.available'),
+            self.is_joined and all(self.get_api_endpoints()))
 
     def get_auth_credentials(self, user):
         """
@@ -147,3 +150,12 @@ class KubeControlRequirer(Endpoint):
         Default CNI network to use.
         """
         return self.all_joined_units.received['default-cni']
+
+    def get_api_endpoints(self):
+        """
+        Returns a list of API endpoint URLs.
+        """
+        endpoints = set()
+        for unit in self.all_joined_units:
+            endpoints.update(unit.received['api-endpoints'] or [])
+        return sorted(endpoints)

--- a/requires.py
+++ b/requires.py
@@ -50,7 +50,7 @@ class KubeControlRequirer(Endpoint):
             self.is_joined and self.get_default_cni() is not None)
         toggle_flag(
             self.expand_name('{endpoint_name}.api_endpoints.available'),
-            self.is_joined and all(self.get_api_endpoints()))
+            self.is_joined and self.get_api_endpoints())
 
     def get_auth_credentials(self, user):
         """


### PR DESCRIPTION
Part of the simplification of how the API server endpoint URLs are passed to the worker charms by making them always come from the master regardless of whether kubeapi-load-balancer is being used and removing a confusing set of two relations which change depending on the deployment in favor of the standard `kube-control` relation plus an optional `lb-provider` relation on the master.

Part of [lp:1921776][]

[lp:1921776]: https://bugs.launchpad.net/charm-kubernetes-master/+bug/1921776