### PR TITLE
Add has_xcp flag for external cloud provider support

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -158,3 +158,10 @@ class KubeControlProvider(Endpoint):
         endpoints = sorted(endpoints)
         for relation in self.relations:
             relation.to_publish['api-endpoints'] = endpoints
+
+    def set_has_xcp(self, has_xcp):
+        """
+        Set the flag indicating that an external cloud provider is in use.
+        """
+        for relation in self.relations:
+            relation.to_publish['has-xcp'] = bool(has_xcp)

--- a/requires.py
+++ b/requires.py
@@ -159,3 +159,10 @@ class KubeControlRequirer(Endpoint):
         for unit in self.all_joined_units:
             endpoints.update(unit.received['api-endpoints'] or [])
         return sorted(endpoints)
+
+    @property
+    def has_xcp(self):
+        """
+        The flag indicating whether an external cloud provider is in use.
+        """
+        return self.all_joined_units.received.get("has-xcp", False)


### PR DESCRIPTION
Adds a new flag for the control plane to inform the workers that an external cloud provider is in use.