### PR TITLE
adds sharing `cluster-cidr` over the kube-control relation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Kubernetes cluster.
 * `kube_control.set_controller_labels(labels)`
   Sends the juju config labels of the control-plane to the connected dependents(s).
 
+* `kube_control.share_cluster_cidr(cluster_cidr)`
+  Shares the cluster_cidr of the connected cni from the control-plane to the connected dependents(s).
+
+
 ### Examples
 
 ```python
@@ -121,6 +125,10 @@ def flush_auth_for_departed(kube_control):
 
   Enabled when control-plane labels are available.
 
+* `kube-control.cluster_cidr.available`
+
+  Enabled when POD cluster-cidr is available.
+
 ### Methods
 
 * `kube_control.get_dns()`
@@ -156,6 +164,10 @@ def flush_auth_for_departed(kube_control):
 * `kube_control.get_controller_labels()`
 
   Returns a list of labels configured on the control-plane nodes.
+
+* `kube_control.get_cluster_cidr()`
+
+  Returns the Pods cluster-cidr shared from control-plane nodes.
 
 
 ### Examples

--- a/ops/ops/interface_kube_control/model.py
+++ b/ops/ops/interface_kube_control/model.py
@@ -1,5 +1,6 @@
+from ipaddress import IPv4Network, IPv6Network
 from pydantic import Field, AnyHttpUrl, BaseModel, Json
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Union
 import re
 
 
@@ -55,6 +56,7 @@ class Creds(BaseModel):
 class Data(BaseModel):
     api_endpoints: Json[List[AnyHttpUrl]] = Field(alias="api-endpoints")
     cluster_tag: str = Field(alias="cluster-tag")
+    cluster_cidr: Union[None, IPv4Network, IPv6Network] = Field(alias="cluster-cidr")
     cohort_keys: Optional[Json[Dict[str, str]]] = Field(alias="cohort-keys")
     creds: Json[Dict[str, Creds]] = Field(alias="creds")
     default_cni: Json[str] = Field(alias="default-cni")

--- a/ops/ops/interface_kube_control/requires.py
+++ b/ops/ops/interface_kube_control/requires.py
@@ -7,6 +7,7 @@ style rather than the reactive style.
 """
 
 import base64
+from ipaddress import ip_network
 import logging
 from os import PathLike
 from pathlib import Path
@@ -223,3 +224,9 @@ class KubeControlRequirer(Object):
     def get_controller_labels(self) -> List[Label]:
         """Returns a list of lables configured on the control-plane nodes."""
         return (self.is_ready and self._data.labels) or []
+
+    def get_cluster_cidr(self) -> Optional[ip_network]:
+        """
+        Tag for identifying resources that are part of the cluster.
+        """
+        return self._data.cluster_cidr if self.is_ready else None

--- a/ops/tests/unit/test_ops_requires.py
+++ b/ops/tests/unit/test_ops_requires.py
@@ -163,4 +163,3 @@ def test_cluster_cidr_ipv6(kube_control_requirer, relation_data):
         relation.data = {"remote/0": relation_data}
         cidr = kube_control_requirer.get_cluster_cidr()
         assert cidr == ip_network("2002:0:0:1234::0/64")
-

--- a/provides.py
+++ b/provides.py
@@ -10,6 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from ipaddress import IPv4Network, IPv6Network
 from typing import List, Union
 from charms.reactive import Endpoint, toggle_flag, set_flag, data_changed
 
@@ -191,3 +192,11 @@ class KubeControlProvider(Endpoint):
         for relation in self.relations:
             relation.to_publish["labels"] = dedup
         return self
+
+    def share_cluster_cidr(self, cluster_cidr: Union[IPv4Network, IPv6Network]):
+        """
+        Send the Pods cluster-cidr to the remote units.
+        This data originates from the attached cni's charms configuration
+        """
+        for relation in self.relations:
+            relation.to_publish_raw.update({"cluster-cidr": str(cluster_cidr)})

--- a/requires.py
+++ b/requires.py
@@ -79,7 +79,6 @@ class KubeControlRequirer(Endpoint):
             self.is_joined and self.get_cluster_cidr(),
         )
 
-
     def get_auth_credentials(self, user):
         """
         Return the authentication credentials.


### PR DESCRIPTION
[LP#2013090](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2013090)

the cni subordinates for kubernetes-control-plane configures the cluster-cidr and it the ultimate source of truth. 

This change allows the kubernetes-control-plane to share the `cluster-cidr` it learns from the CNI to other applications that need to know the `cluster-cidr`