### PR TITLE
Make sdn-ip field optional

### DIFF
--- a/ops/ops/interface_kube_control/model.py
+++ b/ops/ops/interface_kube_control/model.py
@@ -62,7 +62,7 @@ class Data(BaseModel):
     enable_kube_dns: bool = Field(alias="enable-kube-dns")
     has_xcp: Json[bool] = Field(alias="has-xcp")
     port: Json[int] = Field(alias="port")
-    sdn_ip: str = Field(alias="sdn-ip")
+    sdn_ip: Optional[str] = Field(default=None, alias="sdn-ip")
     registry_location: str = Field(alias="registry-location")
     taints: Optional[Json[List[Taint]]] = Field(alias="taints")
     labels: Optional[Json[List[Label]]] = Field(alias="labels")


### PR DESCRIPTION
When kubernetes-control-plane is configured with `dns-provider=none`, it does not send an `sdn-ip` field on the relation. This change is needed to prevent kubernetes-worker get stuck in a "waiting" state due to invalid kube-control relation data.